### PR TITLE
はてブボタンのtitleを2015から2016に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
               </li>
               <li>
-                <a href="http://b.hatena.ne.jp/entry/http://summit.scala-kansai.org/" class="hatena-bookmark-button" data-hatena-bookmark-title="Scala関西 Summit 2015" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a>
+                <a href="http://b.hatena.ne.jp/entry/http://summit.scala-kansai.org/" class="hatena-bookmark-button" data-hatena-bookmark-title="Scala関西 Summit 2016" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a>
               </li>
               <li>
                 <div class="fb-like" data-href="http://summit.scala-kansai.org/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>


### PR DESCRIPTION
はてなブックマークボタンのページタイトルが
`Scala関西 Summit 2015` と2015年のもののままだったようですので、`Scala関西 Summit 2016` に修正しました。

もし変更するなら、[ここ](http://b.hatena.ne.jp/entry/summit.scala-kansai.org/)からはてなブックマークタイトルも変更したほうが良さそう
(以下の部分から変更できるようです)
[![https://gyazo.com/c0a57b72a0d27420f84e0066b90b3d87](https://i.gyazo.com/c0a57b72a0d27420f84e0066b90b3d87.png)](https://gyazo.com/c0a57b72a0d27420f84e0066b90b3d87)

(間違えてgh-pagesブランチからプルリクを出してしまいました...このプルリクが閉じたらすぐにブランチ消します...:bow:)
